### PR TITLE
fix: remove unregistered OpenVSX extensions (SEC-20446)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,5 @@
 {
   "recommendations": [
-    "mikerhyssmith.ts-barrelr",
-    "mike-co.import-sorter",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
     "Tobermory.es6-string-html"


### PR DESCRIPTION
Remove mikerhyssmith.ts-barrelr and mike-co.import-sorter from .vscode/extensions.json - not published on OpenVSX registry, supply-chain risk for OpenVSX-based IDEs. Resolves SEC-20446